### PR TITLE
BioSig Correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Standard PhysioNet citation:
 
 *Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh, Mark RG, Mietus JE, Moody GB, Peng C-K, Stanley HE. PhysioBank, PhysioToolkit, and PhysioNet: Components of a New Research Resource for Complex Physiologic Signals. Circulation 101(23):e215-e220 [Circulation Electronic Pages; http://circ.ahajournals.org/cgi/content/full/101/23/e215]; 2000* 
 
-EEGLAB citation for EDF files conversion:
+BioSig citation for EDF files conversion:
 
-*Arnaud Delorme, Scott Makeig, EEGLAB: an open source toolbox for analysis of single-trial EEG dynamics including independent component analysis, Journal of Neuroscience Methods, Volume 134, Issue 1, 15 March 2004, Pages 9-21*
+*Vidaurre, Carmen, Tilmann H. Sander, and Alois Schlögl. "BioSig: the free and open source software library for biomedical signal processing." Computational intelligence and neuroscience 2011 (2011).*
 
 
 ##Features##
@@ -36,7 +36,7 @@ EEGLAB citation for EDF files conversion:
 
 ## Installation
 * Download or clone the repository and add it to your path
-* **IMPORTANT**: For EDF to Matlab conversion, [EEGLAB](http://sccn.ucsd.edu/eeglab/) is required and its installation must be on the search path
+* **IMPORTANT**: For EDF to Matlab conversion, [BioSig Toolbox](http://biosig.sourceforge.net/download.html) is required and its installation must be on the search path. Just download the MATLAB version and run the installer.
 
 
 
@@ -139,7 +139,7 @@ convertEDFxToMat(saved_file, status)
 * `saved_file` is the full path of the downloaded EDF file 
 * `status` corresponds to the success/failure of each file (it's download status) and should not be 0 which indicates a failed download when used in the workflow
 * The converted files are stored within the test directory
-* This function requires the presence of [EEGLAB](http://sccn.ucsd.edu/eeglab/) toolbox available on the search path
+* This function requires the presence of [BioSig Toolbox](http://biosig.sourceforge.net/) toolbox available on the search path
 
 
 ##### Process hypnogram annotations

--- a/convertEDFxToMat.m
+++ b/convertEDFxToMat.m
@@ -7,7 +7,7 @@ function convertEDFxToMat( saved_file, status )
 %   EEGLAB toolbox.
 
 
-% Check for EEGLAB toolbox
+% Check for EEGLAB toolbox (BioSig plugnin is needed too! [Hassan])
 if exist('eeglab') ~=2
     error('EEGLAB does not exist or not added to search path')
 end
@@ -26,14 +26,16 @@ cd(test_dir);
 current_dir = test_dir;
 
 % Folders to save files in
-mkdir(current_dir, 'matlab'); % Create folder to store matlab variables
-mkdir(current_dir, 'info'); % Create folder to store additional info
+mkdir('matlab'); % Create folder to store matlab variables
+if exist('info', 'dir') == 0,
+    mkdir('info'); % Create folder to store additional info if needed
+end
 
 % Get the edf file by checking for extension
 edf_file_name = dir([file_name file_extension]);
 
-
-% Load edf file in Matlab - requires EEGLAB
+% Load edf file in Matlab - requires BioSig toolbox
+% http://biosig.sourceforge.net/download.html
 [edf, header] = sload(edf_file_name.name);
 
 fprintf('Converting file %s ......\n', edf_file_name.name);

--- a/downloadEDFxData.m
+++ b/downloadEDFxData.m
@@ -51,17 +51,31 @@ for i=1:length(edf_files)
     % extract name of edf file
     this_file = edf_files{i}(2:end-1);
     folder_name = this_file(1:end-8);
-    
+         
     % create folder for download
-    mkdir(download_dir, folder_name);
+    if exist(download_dir, 'dir') == 0,
+        mkdir(download_dir, folder_name);
+    end
     path_of_file = fullfile(download_dir, folder_name, this_file);
     
     % url of the edf file to download
     url_of_file = [edfx_url this_file];
     
+    % Check if files is already downloaded (to avoid re-downloading)
+    if exist(folder_name, 'dir') == 0,
+
+    % don't download the file if it exist
+    fprintf('File already exist file: %s (%d of %d)\n', this_file, i, length(edf_files));
+    fprintf('If you need to re-download the file, delete directory: %s \n', fullfile(download_dir, folder_name));
+    saved_file{i} = path_of_file;
+    status{i} = 1;
+    
+    else
+        
     % download the file
     fprintf('Downloading file: %s (%d of %d)\n', this_file, i, length(edf_files));
     [saved_file{i}, status{i}] = urlwrite(url_of_file,path_of_file);
+    end
 end
 
 fprintf('\nDownload complete!\n')


### PR DESCRIPTION
The toolbox is actually using a function called 'sload' that can be
imported directly from BioSig. EEGLAB doesn't have this function; but it
has a BioSig Plugin that you must install if you're going to go with
EEGLAB.
